### PR TITLE
Add a knobby pipe type.

### DIFF
--- a/pipes.sh
+++ b/pipes.sh
@@ -30,6 +30,7 @@ sets=(
     ".. ....  .... .."
     ".o oo.o  o.oo o."
     "-\ /\|/  /-\/ \|"  # railway
+    "╿┍ ┑┚╼┒  ┕╽┙┖ ┎╾"  # knobby pipe
 )
 v=()
 RNDSTART=0


### PR DESCRIPTION
This one is interesting in that it's the only pattern that uses a different character for each cell type. Lines going up look slightly difference than lines going down, etc. Plus it kinda looks like a worm.

Of course I understand if you want to limit the number of pipe types now that custom types are supported.