### PR TITLE
[WIP] Added dimension support for tmux non-interactive shells.

### DIFF
--- a/pipes.sh
+++ b/pipes.sh
@@ -13,7 +13,11 @@ f=75 s=13 r=2000 t=0
 w=80 h=24
 
 resize() {
-	w=$(tput cols) h=$(tput lines)
+	if [[ $- == *i* ]]; then
+		w=$(tput cols) h=$(tput lines)
+	else
+		w=$(tmux list-panes -F "#{pane_width}") h=$(tmux list-panes -F "#{pane_height}")
+	fi
 }
 
 # ab -> idx = a*4 + b


### PR DESCRIPTION
I had to add this because when I was using pipes.sh in tmux's lock screen, it was only showing in a small portion of the window.