### PR TITLE
make it work on OS X

### DIFF
--- a/pipes.sh
+++ b/pipes.sh
@@ -125,8 +125,8 @@ while REPLY=; read -t 0.0$((1000/f)) -n 1 2>/dev/null; [[ -z $REPLY ]] ; do
 
         # Print:
         tput cup ${y[i]} ${x[i]}
-        echo -ne "\e[${BOLD}m"
-        [[ $NOCOLOR == 0 ]] && echo -ne "\e[3${c[i]}m"
+        echo -ne "\033[${BOLD}m"
+        [[ $NOCOLOR == 0 ]] && echo -ne "\033[3${c[i]}m"
         echo -n "${sets[v[i]]:l[i]*4+n[i]:1}"
         l[i]=${n[i]}
     done


### PR DESCRIPTION
I might be crazy, but trying to run the master branch on OS X fails to output in color (tested with all available shells, including my default, bash 4.3.39(1)-release). This fixes that..