### PR TITLE
ESC sequence replaced.

### DIFF
--- a/pipes.sh
+++ b/pipes.sh
@@ -13,7 +13,7 @@ f=75 s=13 r=2000 t=0
 w=80 h=24
 
 resize() {
-	w=$(tput cols) h=$(tput lines)
+    w=$(tput cols) h=$(tput lines)
 }
 
 # ab -> idx = a*4 + b

--- a/pipes.sh
+++ b/pipes.sh
@@ -87,7 +87,7 @@ cleanup() {
     tput rmcup
     tput cnorm
     stty echo
-    ((NOCOLOR)) && echo -ne '\e[0m'
+    ((NOCOLOR)) && echo -ne '\x1b[0m'
     exit 0
 }
 trap resize SIGWINCH
@@ -125,8 +125,8 @@ while REPLY=; read -t 0.0$((1000/f)) -n 1 2>/dev/null; [[ -z $REPLY ]] ; do
 
         # Print:
         tput cup ${y[i]} ${x[i]}
-        echo -ne "\e[${BOLD}m"
-        [[ $NOCOLOR == 0 ]] && echo -ne "\e[3${c[i]}m"
+        echo -ne "\x1b[${BOLD}m"
+        [[ $NOCOLOR == 0 ]] && echo -ne "\x1b[3${c[i]}m"
         echo -n "${sets[v[i]]:l[i]*4+n[i]:1}"
         l[i]=${n[i]}
     done


### PR DESCRIPTION
I replaced the ESC character to be encoded as an HEX ASCII instead of a Shell one

`\e` becomes `\xb1`

This way it works in a more wide set of terminals.