### PR TITLE
fix #22 last pipe color issue for konsole

### DIFF
--- a/pipes.sh
+++ b/pipes.sh
@@ -113,6 +113,7 @@ cleanup() {
     # terminal has no smcup and rmcup capabilities
     ((FORCE_RESET)) && reset && exit 0
 
+    tput reset
     tput rmcup
     tput cnorm
     stty echo


### PR DESCRIPTION
The second proposed method, by @parkercoates in #22, can be implemented safely for terminal emulators which are not affected by the issue.