### PR TITLE
add benchmark script

### DIFF
--- a/scripts/README
+++ b/scripts/README
@@ -1,0 +1,119 @@
+benchmark.sh
+
+    Benchmarking pipes.sh by revisions excluding terminal render time
+    
+    Usage:
+
+        $ scripts/benchmark.sh <revision>...
+
+    Example outputs:
+
+	$ TIMEF=time_ndis scripts/benchmark.sh f7d0941 $(git tag) HEAD
+	f7d0941   :    558 c/s
+	2013-02-01:    539 c/s
+	2013-02-06:    532 c/s
+	2013-02-07:    555 c/s
+	2014-02-20:    536 c/s
+	2014-02-21:    543 c/s
+	v0.1.0    :    542 c/s
+	v0.1.1    :    534 c/s
+	v0.2.0    :    550 c/s
+	v1.0.0    :    528 c/s
+	v1.1.0    :    541 c/s
+	v1.2.0    :    531 c/s
+	v1.3.0    :    503 c/s
+	HEAD      :   3115 c/s
+
+	$ TIMEF=time_disp scripts/benchmark.sh f7d0941 $(git tag) HEAD
+	f7d0941   :    493 c/s
+	2013-02-01:    457 c/s
+	2013-02-06:    450 c/s
+	2013-02-07:    464 c/s
+	2014-02-20:    460 c/s
+	2014-02-21:    464 c/s
+	v0.1.0    :    453 c/s
+	v0.1.1    :    463 c/s
+	v0.2.0    :    452 c/s
+	v1.0.0    :    451 c/s
+	v1.1.0    :    459 c/s
+	v1.2.0    :    443 c/s
+	v1.3.0    :    439 c/s
+	HEAD      :   2659 c/s
+
+    Method:
+
+        This script uses Bash keyword time to measure the execution time t of 
+        pipes.sh for certain amount of pipe characters -- through -r LIMIT -- 
+        which is 1000 by default.
+
+        Without modifications, pipes.sh runs forever with timing control, 
+        therefore mkp_pipes() monkey-patches pipes.sh in order to
+
+        * make read builtin as nop using : builtin
+
+          We do not want the delay which is one of two purpose of using read, 
+          we want pipes.sh to pipe out the pipe as fast as it can.
+
+        * exit and cleanup when reach -r LIMIT characters
+
+        * have a (logical) terminal size 80x24
+
+        The time returns a real time (%R) t, which is used to calculate with 
+        LIMIT for a performance index, pipe chars per second:
+
+            cps = LIMIT / t
+
+        cps is calculated by bc program since Bash can not handle float 
+        numbers.
+
+    Environment variables:
+
+        LIMIT
+
+            Used for pipes.sh option -r LIMIT.
+
+        TIMEF
+
+            The timing helper function, whose value can be one of:
+
+            * time_ndis (default)
+
+                Do not time terminal render time by sending pipes to /dev/null
+
+            * time_disp
+
+                Time terminal render time
+
+    Important notes:
+
+        * It benchmarks with default options of each revision's pipes.sh
+        
+        * It excludes terminal render time
+
+        It's impossible to enforce the options as development goes, and the 
+        whole purpose of benchmarking is to have a (at least) comparable 
+        performance index that we can compare as we attempt to improve and 
+        optimize the code.
+
+        If without the latter, that is not excluding the terminal render time, 
+        the index would be clouded and even distorted, because you can't
+        actually guarantee
+
+        a) the improvement works for another terminal (emulator) in part of 
+           render.  This also means whatever you do to the code, it might have 
+           opposite effect in another terminal in term of execution time; and
+
+        b) the render in terminal may have or haven't been optimized that could 
+           affect the speed of render, which might also based on what and how 
+           data the terminal receives.
+
+        c) consistence of each run.  When render in X Window, there are more 
+           coming into affecting the performance.  With each component 
+           inevitably layered up -- not just terminal (emulator) and X Window 
+           System, e.g.  there is also font system -- each could vary the 
+           execution time, in turn, the level of variation increases.
+
+        In other words, with render part, the results of revisions are less 
+        comparable, which defeats the purpose of having a benchmark, therefore 
+        this benchmark script (so should the improvement) only focuses on the 
+        internal part, and excluding the terminal render time.

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Benchmark pipes.sh by revisions
+# Benchmark pipes.sh by revisions excluding terminal render time
 # Copyright (c) 2018 Pipeseroni/pipes.sh contributors
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +34,7 @@
 
 
 PIPESSH='pipes.sh'
-LIMIT=1000
+LIMIT=${LIMIT:-1000}
 
 SED_E=(
     -e 's/read\|sleep\|cat/:/g'  # NOP
@@ -61,15 +61,19 @@ mkp_pipes() {
 }
 
 
-# time the monkey-patched gitrevision $1 pipes.sh with Bash builtiin time.
+# time the monkey-patched gitrevision $1 pipes.sh with Bash time keyword.
 # The stdout and stderr are swapped.  So the pipes are on stderr and time's
 # result (real %e) is on stdout.
 run() {
-    TIME=%e time bash <(mkp_pipes "$1") -r $LIMIT 3>&2 2>&1 1>&3
+    local TIMEFORMAT=%R
+    {
+        time bash <(mkp_pipes "$1") -r $LIMIT
+    } 3>&2 2>&1 1>&3
 }
 
 
-# benchmark a gitrevision ($1) pipes.sh, the result is pipe chars per second.
+# benchmark a gitrevision ($1) pipes.sh without terminal render time
+# (2>/dev/null), the result is pipe chars per second.
 benchmark() {
     local t=$(run "$1" 2>/dev/null)
     local cps="$(bc <<< "$LIMIT/$t")"

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -19,18 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-# Usage: scripts/benchmark.sh <revision>...
-#
-# Example:
-#
-#     $ scripts/benchmark.sh f7d0941 $(git tag) HEAD
-#     f7d0941   :    564 c/s
-#     2013-02-01:    534 c/s
-#     2013-02-06:    534 c/s
-#     [snip]
-#     v1.2.0    :    529 c/s
-#     v1.3.0    :    492 c/s
-#     HEAD      :   3030 c/s
+# Usage: see scripts/README.
 
 
 PIPESSH='pipes.sh'

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -39,6 +39,8 @@ LIMIT=${LIMIT:-1000}
 SED_E=(
     -e 's/read\|sleep\|cat/:/g'  # NOP
     -e 's/! :/:/'                # ! read -> ! : -> :
+    -e 's/tput cols/echo 80/'    # 80x24
+    -e 's/tput lines/echo 24/'
 )
 SED_CLNUP=("${SED_E[@]}" -e 's/&& t=0/\&\& cleanup/')
 SED_BREAK=("${SED_E[@]}" -e 's/&& t=0/\&\& break/')
@@ -47,6 +49,7 @@ SED_BREAK=("${SED_E[@]}" -e 's/&& t=0/\&\& break/')
 # monkey-patch gitrevision $1 pipes.sh:
 # 1. make read/sleep/cat nop
 # 2. exit when reach -r LIMIT
+# 3. have a (logical) terminal size 80x24
 #
 # Some early commits use sleep to work around Bash < 4 for delay < 1 second,
 # and cat is used to clear out standard input, which could hang if not made

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Benchmark pipes.sh by revisions
+# Copyright (c) 2018 Pipeseroni/pipes.sh contributors
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# Usage: scripts/benchmark.sh <revision>...
+#
+# Example:
+#
+#     $ scripts/benchmark.sh f7d0941 $(git tag) HEAD
+#     f7d0941   :    564 c/s
+#     2013-02-01:    534 c/s
+#     2013-02-06:    534 c/s
+#     [snip]
+#     v1.2.0    :    529 c/s
+#     v1.3.0    :    492 c/s
+#     HEAD      :   3030 c/s
+
+
+PIPESSH='pipes.sh'
+LIMIT=1000
+
+SED_E=(
+    -e 's/read\|sleep\|cat/:/g'  # NOP
+    -e 's/! :/:/'                # ! read -> ! : -> :
+)
+SED_CLNUP=("${SED_E[@]}" -e 's/&& t=0/\&\& cleanup/')
+SED_BREAK=("${SED_E[@]}" -e 's/&& t=0/\&\& break/')
+
+
+# monkey-patch gitrevision $1 pipes.sh:
+# 1. make read/sleep/cat nop
+# 2. exit when reach -r LIMIT
+#
+# Some early commits use sleep to work around Bash < 4 for delay < 1 second,
+# and cat is used to clear out standard input, which could hang if not made
+# nop.
+mkp_pipes() {
+    local GIT=(git cat-file --textconv "$1:$PIPESSH")
+    if "${GIT[@]}" | grep cleanup &>/dev/null; then
+        "${GIT[@]}" | sed "${SED_CLNUP[@]}"
+    else
+        "${GIT[@]}" | sed "${SED_BREAK[@]}"
+    fi
+}
+
+
+# time the monkey-patched gitrevision $1 pipes.sh with Bash builtiin time.
+# The stdout and stderr are swapped.  So the pipes are on stderr and time's
+# result (real %e) is on stdout.
+run() {
+    TIME=%e time bash <(mkp_pipes "$1") -r $LIMIT 3>&2 2>&1 1>&3
+}
+
+
+# benchmark a gitrevision ($1) pipes.sh, the result is pipe chars per second.
+benchmark() {
+    local t=$(run "$1" 2>/dev/null)
+    local cps="$(bc <<< "$LIMIT/$t")"
+    printf '%-10s: %6d c/s\n' "$1" "$cps"
+}
+
+
+main() {
+    while (($#)); do
+        benchmark "$1"
+        shift
+    done
+}
+
+
+main "$@"


### PR DESCRIPTION
This script takes/benchmarks revisions of pipes.sh, showing results in pipe chars per second, an example for the first commit, current tags, and previous commit (918684b) is:

    $ scripts/benchmark.sh f7d0941 $(git tag) HEAD
    f7d0941   :    564 c/s
    2013-02-01:    534 c/s
    2013-02-06:    534 c/s
    2013-02-07:    540 c/s
    2014-02-20:    531 c/s
    2014-02-21:    552 c/s
    v0.1.0    :    537 c/s
    v0.1.1    :    534 c/s
    v0.2.0    :    526 c/s
    v1.0.0    :    534 c/s
    v1.1.0    :    529 c/s
    v1.2.0    :    529 c/s
    v1.3.0    :    492 c/s
    HEAD      :   3030 c/s

(a dip in v1.3.0 and boost because of not using `tput cup` (c582ec0))

pipes.sh is monkey-patched, so that it doesn't have any delays, that is replacing `read` with `:`.  Also exiting when reaching `-r LIMIT`, which is set to 1000.

With execution time (real %e) measured by Bash time builtiin, it calculates pipe chars per second.