### PR TITLE
use '.' to refer to pipes.sh in working directory for benchmark

### DIFF
--- a/scripts/README
+++ b/scripts/README
@@ -117,3 +117,10 @@ benchmark.sh
         comparable, which defeats the purpose of having a benchmark, therefore 
         this benchmark script (so should the improvement) only focuses on the 
         internal part, and excluding the terminal render time.
+
+    Other notes:
+
+        * pipes.sh revision references:
+
+            * ''  (empty string): index (staged)
+            * '.' (single dot)  : working directory

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -45,7 +45,14 @@ SED_BREAK=("${SED_E[@]}" -e 's/&& t=0/\&\& break/')
 # and cat is used to clear out standard input, which could hang if not made
 # nop.
 mkp_pipes() {
-    local GIT=(git cat-file --textconv "$1:$PIPESSH")
+    local GIT
+    # . refers to pipes.sh in working directory
+    if [[ $1 == . ]]; then
+        # may not always be run in reposistory root, could be under scripts/
+        GIT=(cat "$PWD/$(dirname "${BASH_SOURCE[0]}")/../$PIPESSH")
+    else
+        GIT=(git cat-file --textconv "$1:$PIPESSH")
+    fi
     if "${GIT[@]}" | grep cleanup &>/dev/null; then
         "${GIT[@]}" | sed "${SED_CLNUP[@]}"
     else
@@ -82,7 +89,7 @@ time_disp() {
 benchmark() {
     local t=$($TIMEF "$1")
     local cps="$(bc <<< "$LIMIT/$t")"
-    printf '%-10s: %6d c/s\n' "$1" "$cps"
+    printf '%-10s: %6d c/s\n' "${1:-staged}" "$cps"
 }
 
 

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -49,7 +49,7 @@ mkp_pipes() {
     # . refers to pipes.sh in working directory
     if [[ $1 == . ]]; then
         # may not always be run in reposistory root, could be under scripts/
-        GIT=(cat "$PWD/$(dirname "${BASH_SOURCE[0]}")/../$PIPESSH")
+        GIT=(cat "$(dirname "${BASH_SOURCE[0]}")/../$PIPESSH")
     else
         GIT=(git cat-file --textconv "$1:$PIPESSH")
     fi


### PR DESCRIPTION
Also note that `''` can be used for index/staged `pipes.sh`.

I can't find a way that can refer to the `pipes.sh` of working directory to be used in `git cat-file`, if there is one, please do let me know.

Although we can always stage the script, with both staged and of working directory, one can fine tune and compare against the staged before committing.