### PR TITLE
improve -c color for 256/24-bit colors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == 'osx' ]]; then brew install shunit2; fi
 
 before_script:
+  - tput -V
   - groff --version
   - if [[ "$TRAVIS_OS_NAME" != 'osx' ]]; then sed --version; fi
 

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,10 @@ Requirements
 
 * Bash 4+ since version 1.0.0.
 
+* ncurses for ``tput``
+
+    * >= 6.1 (2018-01-27) for 24-bit colors and ``TERM=*-direct``.
+
 
 Installation
 ============
@@ -120,16 +124,6 @@ For example, ``-t cMAYFORCEBWITHYOU``.
   xsnap -region 640x140+$((2+2))+$((20+2)) -file i/pipes.tc.png
 
 .. figure:: i/pipes.tc.png
-
-
-``-c [0-7]``: colors
---------------------
-
-+---+------------+---+------------+---+------------+---+------------+
-| 0 | background | 1 | red        | 2 | green      | 3 | yellow     |
-+---+------------+---+------------+---+------------+---+------------+
-| 4 | blue       | 5 | magenta    | 6 | cyan       | 7 | foreground |
-+---+------------+---+------------+---+------------+---+------------+
 
 
 Controls

--- a/pipes.sh
+++ b/pipes.sh
@@ -93,7 +93,11 @@ parse() {
                 ((OPTARG >= 0 && OPTARG < ${#sets[@]})) && V+=($OPTARG)
             fi
             ;;
-        c) ((OPTARG > 0 && OPTARG < COLORS)) && C+=($OPTARG);;
+        c)
+            local _color=$OPTARG
+            [[ $_color == '#'* ]] && ((_color = 16$_color))
+            ((_color > 0 && _color < COLORS)) && C+=($_color)
+            ;;
         f) ((f = (OPTARG > 19 && OPTARG < 101) ? OPTARG : f));;
         s) ((s = (OPTARG > 4 && OPTARG < 16) ? OPTARG : s));;
         r) ((r = (OPTARG >= 0) ? OPTARG : r));;
@@ -105,7 +109,9 @@ parse() {
             echo -e "Animated pipes terminal screensaver.\n"
             echo -e " -p [1-]\tnumber of pipes (D=1)."
             echo -e " -t [0-$((${#sets[@]} - 1))]\ttype of pipes, can be used more than once (D=0)."
-            echo -e " -c [COLORS]\tcolor index of pipes, valid index is in [0-$((COLORS - 1))], can be used more than once (D=1 2 3 4 5 6 7 0)."
+            echo -e " -c [COLORS]\tcolor index of pipes, valid index is in [0-$((COLORS - 1))],
+\t\tcan be hexdecimal with '#' prefix, can be used
+\t\tmore than once (D=1 2 3 4 5 6 7 0)."
             echo -e " -t c[16 chars]\tcustom type of pipes."
             echo -e " -f [20-100]\tframerate (D=75)."
             echo -e " -s [5-15]\tprobability of a straight fitting (D=13)."

--- a/pipes.sh
+++ b/pipes.sh
@@ -108,7 +108,7 @@ parse() {
             echo -e " -p [1-]\tnumber of pipes (D=1)."
             echo -e " -t [0-$((${#sets[@]} - 1))]\ttype of pipes, can be used more than once (D=0)."
             echo -e " -c [COLORS]\tcolor index of pipes, valid index is in [0-$((COLORS - 1))],
-\t\tcan be hexdecimal with '#' prefix, can be used
+\t\tcan be hexadecimal with '#' prefix, can be used
 \t\tmore than once (D=1 2 3 4 5 6 7 0)."
             echo -e " -t c[16 chars]\tcustom type of pipes."
             echo -e " -f [20-100]\tframerate (D=75)."

--- a/pipes.sh.6
+++ b/pipes.sh.6
@@ -121,8 +121,26 @@ Straight left
 .RE
 
 .TP
-.B -c [0-7]
-Colors of pipes. Multiple arguments can be used. (default is 1 2 3 4 5 6 7 0)
+.B -c [0-(COLORS-1)]
+Color index of pipes. Multiple arguments can be used. (default is 1 2 3 4 5 6 7
+0)
+
+\fICOLORS\fR is the available colors depending on \fB$TERM\fR capability.  For
+examples, \fBxterm\fR has 8 colors, \fBxterm-256color\fR has 256 colors, and
+\fBxterm-direct\fR -- requires ncurses 6.1+ -- has 16,777,216 colors.
+
+The color index is used to generate escape code using \fBtput setaf
+color_index\fR.
+
+For 256 colors, you may use 0 to 255 as color index.  For 16,777,216 colors,
+the index can be calculated with three color components,  R * 65536 + G * 256 +
+B (0 <= R, G, B < 256).
+
+See also
+.UR https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
+Wikipedia
+.UE .
+
 .TP
 .B -f [20-100]
 Frame rate. (default is 75)

--- a/pipes.sh.6
+++ b/pipes.sh.6
@@ -136,7 +136,7 @@ For 256 colors, you may use 0 to 255 as color index.  For 16,777,216 colors,
 the index can be calculated with three color components,  R * 65536 + G * 256 +
 B (0 <= R, G, B < 256).
 
-You can also use hexdecimal, for examples:
+You can also use hexadecimal, for examples:
 .RS 8
 .TP 12
 -c\fB#ffff\fR

--- a/pipes.sh.6
+++ b/pipes.sh.6
@@ -136,10 +136,25 @@ For 256 colors, you may use 0 to 255 as color index.  For 16,777,216 colors,
 the index can be calculated with three color components,  R * 65536 + G * 256 +
 B (0 <= R, G, B < 256).
 
+You can also use hexdecimal, for examples:
+.RS 8
+.TP 12
+-c\fB#ffff\fR
+# cyan color
+.TP
+-c\fB#FFA500\fR
+# orange color
+.TP
+-c\fB#64\fR
+# for 256color index 100
+.RE
+
+.RS
 See also
 .UR https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
 Wikipedia
 .UE .
+.RE
 
 .TP
 .B -f [20-100]

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -21,6 +21,7 @@
 
 TEST_DIR="$(dirname "${BASH_SOURCE[0]}")"
 PIPESSH="$TEST_DIR/../pipes.sh"
+TEST_TERM=xterm
 
 
 # cherrypick a piece of code to test and replace RANDOM with a mock, see _RND
@@ -142,4 +143,11 @@ run() {
     status=$?
     # load the output of command into lines without trailing newlines
     mapfile -t lines < <(printf "$_lines")
+}
+
+
+# `cat -v` on $1 and $2 into $_exp and $_ret
+CATV_EXP_RET() {
+    _exp=$(printf "$1" | cat -v)
+    _ret=$(printf "$2" | cat -v)
 }

--- a/test/test_command.sh
+++ b/test/test_command.sh
@@ -25,7 +25,7 @@ source "$(dirname "${BASH_SOURCE[0]}")"/helper.sh
 
 
 test_command_help() {
-    run "$PIPESSH" -h
+    TERM=$TEST_TERM run "$PIPESSH" -h
 
     $_ASSERT_EQUALS_ 0 "$status"
     # if there is something, it might be working
@@ -34,11 +34,18 @@ test_command_help() {
 
 
 test_command_version() {
-    run "$PIPESSH" -v
+    TERM=$TEST_TERM run "$PIPESSH" -v
 
     $_ASSERT_EQUALS_ 0 "$status"
     local VER="$(sed -n '/^VERSION=/ s/VERSION=//p' "$PIPESSH")"
     $_ASSERT_EQUALS_ "'pipes.sh $VER'" "'${lines[0]}'"
+}
+
+
+test_command_TERM() {
+    TERM='NOSUCHTERMWHATSOEVER' run "$PIPESSH" -v 2>/dev/null
+
+    $_ASSERT_EQUALS_ 3 "$status"
 }
 
 

--- a/test/test_init.sh
+++ b/test/test_init.sh
@@ -33,6 +33,7 @@ setUp() {
 
     C=(1 2 3 4 5 6 7 0) CN=8
     V=(0 1 2 3 4 5 6)   VN=7
+    E=(A B C D E F G H)
 
     _RND_init
 }
@@ -52,9 +53,9 @@ test_2pipes() {
     _CP_init_pipes
 
     $_ASSERT_EQUALS_ 2 "${#n[@]}"
-    $_ASSERT_EQUALS_ "${C[_ci]}"     "${c[0]}"
+    $_ASSERT_EQUALS_ "${E[_ci]}"     "${c[0]}"
     $_ASSERT_EQUALS_ "${V[_vi]}"     "${v[0]}"
-    $_ASSERT_EQUALS_ "${C[_ci + 1]}" "${c[1]}"
+    $_ASSERT_EQUALS_ "${E[_ci + 1]}" "${c[1]}"
     $_ASSERT_EQUALS_ "${V[_vi + 1]}" "${v[1]}"
 }
 

--- a/test/test_main.sh
+++ b/test/test_main.sh
@@ -33,9 +33,14 @@ setUp() {
     l[i]=0  n[i]=0
     x[i]=0  y[i]=0
 
-      C=(1 2 3)      V=(4 5 6)
-     CN=${#C[@]}    VN=${#C[@]}
-    c[i]=${C[0]}  v[i]=${V[0]}
+    C=(1 2 3)
+    E=(X Y Z)
+    c=(X Y Z)
+    CN=${#C[@]}
+
+    V=(4 5 6)
+    v=(4 5 6)
+    VN=${#C[@]}
 
     sets[V[i]]='0123456789ABCDEF'
 
@@ -107,10 +112,10 @@ test_cross() {
     local _test_fields=10
     local _tests=(
         # edge    x   y   l  nx  ny  KEEPCT  c            v            RND
-        'top'     10   0  0  10  19  0       "${C[_ci]}"  "${V[_vi]}"  "$_RND"
-        'right'   19  10  1   0  10  0       "${C[_ci]}"  "${V[_vi]}"  "$_RND"
-        'bottom'  10  19  2  10   0  0       "${C[_ci]}"  "${V[_vi]}"  "$_RND"
-        'left'     0  10  3  19  10  0       "${C[_ci]}"  "${V[_vi]}"  "$_RND"
+        'top'     10   0  0  10  19  0       "${c[_ci]}"  "${V[_vi]}"  "$_RND"
+        'right'   19  10  1   0  10  0       "${c[_ci]}"  "${V[_vi]}"  "$_RND"
+        'bottom'  10  19  2  10   0  0       "${c[_ci]}"  "${V[_vi]}"  "$_RND"
+        'left'     0  10  3  19  10  0       "${c[_ci]}"  "${V[_vi]}"  "$_RND"
         'top'     10   0  0  10  19  1       "${c[i]}"    "${v[i]}"    ''
         'right'   19  10  1   0  10  1       "${c[i]}"    "${v[i]}"    ''
         'bottom'  10  19  2  10   0  1       "${c[i]}"    "${v[i]}"    ''
@@ -158,51 +163,24 @@ test_newdir_turning() {
 
 
 test_cur_pos() {
-    local exp ret
     x[i]=3  y[i]=5
-    exp='^[['$((y[i] + 1))';'$((x[i] + 1))'H^[['$BOLD'm^[[31m0'
-    ret=$(_CP_print | cat -v)
-    $_ASSERT_EQUALS_ "'$exp'" "'$ret'"
-}
-
-
-test_BOLD() {
-    local exp ret
-    BOLD=0
-    exp='^[['$((y[i] + 1))';'$((x[i] + 1))'H^[['$BOLD'm^[[31m0'
-    ret=$(_CP_print | cat -v)
-    $_ASSERT_EQUALS_ "'$exp'" "'$ret'"
-    BOLD=1
-    exp='^[['$((y[i] + 1))';'$((x[i] + 1))'H^[['$BOLD'm^[[31m0'
-    ret=$(_CP_print | cat -v)
-    $_ASSERT_EQUALS_ "'$exp'" "'$ret'"
-}
-
-
-test_NOCOLOR() {
-    local exp ret
-    NOCOLOR=0
-    exp='^[['$((y[i] + 1))';'$((x[i] + 1))'H^[['$BOLD'm^[[31m0'
-    ret=$(_CP_print | cat -v)
-    $_ASSERT_EQUALS_ "'$exp'" "'$ret'"
-    NOCOLOR=1
-    exp='^[['$((y[i] + 1))';'$((x[i] + 1))'H^[['$BOLD'm^[[0m0'
-    ret=$(_CP_print | cat -v)
-    $_ASSERT_EQUALS_ "'$exp'" "'$ret'"
+    local _exp _ret
+    CATV_EXP_RET $'\e['$((y[i] + 1))';'$((x[i] + 1))'HX0' "$(_CP_print)"
+    $_ASSERT_EQUALS_ "'$_exp'" "'$_ret'"
 }
 
 
 test_sets_ln() {
-    local _li _ni _I ret
+    local _li _ni _I _ret
 
     for ((_li = 0; _li < 4; _li++)); do
        l[i]=_li
         for ((_ni = 0; _ni < 4; _ni++)); do
             n[i]=_ni
             printf -v _I '%X' $((_li * 4 + _ni))
-            ret=$(_CP_print)
-            ret=${ret:${#ret} - 1}
-            $_ASSERT_EQUALS_ "'l=$_li  n=$_ni  I=$_I'" "$_I" "$ret"
+            _ret=$(_CP_print)
+            _ret=${_ret: -1}  # oh dear Bash, you love space, don't you?
+            $_ASSERT_EQUALS_ "'l=$_li  n=$_ni  I=$_I'" "$_I" "$_ret"
         done
     done
 }

--- a/test/test_parse.sh
+++ b/test/test_parse.sh
@@ -29,10 +29,41 @@ setUp() {
 }
 
 
+test_COLORS() {
+    TERM=$TEST_TERM parse
+    $_ASSERT_EQUALS_ 8 $COLORS
+    TERM=xterm-16color parse
+    $_ASSERT_EQUALS_ 16 $COLORS
+    TERM=xterm-256color parse
+    $_ASSERT_EQUALS_ 256 $COLORS
+    # skipping when xterm-direct not in terminfo, likely because ncurses is not
+    # >= 6.1.  FIXME: remove this when 6.1 is commonly available.
+    if ! tput -T xterm-direct sgr0 &>/dev/null; then
+        printf '%s%s is not available, test skipped%s\n' \
+               "$(tput setf 5)" xterm-direct "$(tput sgr0)" >&2
+        return
+    fi
+    TERM=xterm-direct parse
+    $_ASSERT_EQUALS_ 16777216 $COLORS
+}
+
+
+test_SGRs() {
+    TERM=$TEST_TERM parse
+
+    local _exp _ret
+    CATV_EXP_RET     $'\e(B\e[m' "$SGR0"
+    $_ASSERT_EQUALS_ "'$_exp'"   "'$_ret'"
+
+    CATV_EXP_RET     $'\e[1m'    "$SGR_BOLD"
+    $_ASSERT_EQUALS_ "'$_exp'"   "'$_ret'"
+}
+
+
 # this fails when default settings are changed, which should be not changed
 # without a discussion.
 test_default_settings() {
-    parse
+    TERM=$TEST_TERM parse
 
     $_ASSERT_EQUALS_    1 "$p"
     $_ASSERT_EQUALS_   75 "$f"
@@ -53,21 +84,21 @@ test_default_settings() {
 
 
 test_p_0_invalid() {
-    parse -p 0
+    TERM=$TEST_TERM parse -p 0
 
     $_ASSERT_EQUALS_ 1 "$p"
 }
 
 
 test_p_2() {
-    parse -p 2
+    TERM=$TEST_TERM parse -p 2
 
     $_ASSERT_EQUALS_ 2 "$p"
 }
 
 
 test_t_3() {
-    parse -t 3
+    TERM=$TEST_TERM parse -t 3
 
     $_ASSERT_EQUALS_ 3 "'${V[@]}'"
     $_ASSERT_EQUALS_ 1 "$VN"
@@ -75,7 +106,7 @@ test_t_3() {
 
 
 test_t_3_1_4() {
-    parse -t 3 -t 1 -t 4
+    TERM=$TEST_TERM parse -t 3 -t 1 -t 4
 
     $_ASSERT_EQUALS_ "'3 1 4'" "'${V[*]}'"
     $_ASSERT_EQUALS_ 3 "$VN"
@@ -83,7 +114,7 @@ test_t_3_1_4() {
 
 
 test_t_999_outofrange() {
-    parse -t 999
+    TERM=$TEST_TERM parse -t 999
 
     $_ASSERT_EQUALS_ 0 "'${V[*]}'"
     $_ASSERT_EQUALS_ 1 "$VN"
@@ -92,14 +123,14 @@ test_t_999_outofrange() {
 
 test_t_custom() {
     local _t=fedcba9876543210
-    parse -t "c$_t"
+    TERM=$TEST_TERM parse -t "c$_t"
 
     $_ASSERT_EQUALS_ "$_t" "${sets[V[VN-1]]}"
 }
 
 
 test_c_3() {
-    parse -c 3
+    TERM=$TEST_TERM parse -c 3
 
     $_ASSERT_EQUALS_ 3 "'${C[*]}'"
     $_ASSERT_EQUALS_ 1 "$CN"
@@ -107,7 +138,7 @@ test_c_3() {
 
 
 test_c_3_1_4() {
-    parse -c 3 -c 1 -c 4
+    TERM=$TEST_TERM parse -c 3 -c 1 -c 4
 
     $_ASSERT_EQUALS_ "'3 1 4'" "'${C[*]}'"
     $_ASSERT_EQUALS_ 3 "$CN"
@@ -115,7 +146,7 @@ test_c_3_1_4() {
 
 
 test_c_8_outofrange() {
-    parse -c 8
+    TERM=$TEST_TERM parse -c 8
 
     $_ASSERT_EQUALS_ "'1 2 3 4 5 6 7 0'" "'${C[*]}'"
     $_ASSERT_EQUALS_ 8 "$CN"
@@ -123,54 +154,114 @@ test_c_8_outofrange() {
 
 
 test_f_50() {
-    parse -f 50
+    TERM=$TEST_TERM parse -f 50
 
     $_ASSERT_EQUALS_ 50 "$f"
 }
 
 
 test_f_10_invalid() {
-    parse -f 10
+    TERM=$TEST_TERM parse -f 10
 
     $_ASSERT_EQUALS_ 75 "$f"
 }
 
 
 test_s_10() {
-    parse -s 10
+    TERM=$TEST_TERM parse -s 10
 
     $_ASSERT_EQUALS_ 10 "$s"
 }
 
 
 test_s_30_invalid() {
-    parse -s 30
+    TERM=$TEST_TERM parse -s 30
 
     $_ASSERT_EQUALS_ 13 "$s"
 }
 
 
 test_r_0() {
-    parse -r 0
+    TERM=$TEST_TERM parse -r 0
 
     $_ASSERT_EQUALS_ 0 "$r"
 }
 
 
 test_r__1_invalid() {
-    parse -r -1
+    TERM=$TEST_TERM parse -r -1
 
     $_ASSERT_EQUALS_ 2000  "$r"
 }
 
 
 test_RBCK() {
-    parse -R -B -C -K
+    TERM=$TEST_TERM parse -R -B -C -K
 
     $_ASSERT_EQUALS_ 1 "$RNDSTART"
     $_ASSERT_EQUALS_ 0 "$BOLD"
     $_ASSERT_EQUALS_ 1 "$NOCOLOR"
     $_ASSERT_EQUALS_ 1 "$KEEPCT"
+}
+
+
+test_E() {
+    local _tests_fields=5
+    local _tests=(
+    #   TERM            BOLD    C  E
+    #                      NOCOLOR
+        $TEST_TERM      0  0    3  $'\e(B\e[m\e[33m'
+        xterm-16color   0  0    3  $'\e(B\e[m\e[33m'
+        xterm-256color  0  0    3  $'\e(B\e[m\e[33m'
+        xterm-direct    0  0    3  $'\e(B\e[m\e[33m'
+        xterm-256color  0  0   73  $'\e(B\e[m\e[38;5;73m'
+        xterm-direct    0  0   73  $'\e(B\e[m\e[38:2::0:0:73m'
+        xterm-direct    0  0  273  $'\e(B\e[m\e[38:2::0:1:17m'
+
+        $TEST_TERM      1  0    3  $'\e(B\e[m\e[1m\e[33m'
+        xterm-16color   1  0    3  $'\e(B\e[m\e[1m\e[33m'
+        xterm-256color  1  0    3  $'\e(B\e[m\e[1m\e[33m'
+        xterm-direct    1  0    3  $'\e(B\e[m\e[1m\e[33m'
+        xterm-256color  1  0   73  $'\e(B\e[m\e[1m\e[38;5;73m'
+        xterm-direct    1  0   73  $'\e(B\e[m\e[1m\e[38:2::0:0:73m'
+        xterm-direct    1  0  273  $'\e(B\e[m\e[1m\e[38:2::0:1:17m'
+
+        $TEST_TERM      0  1    3  $'\e(B\e[m'
+        xterm-16color   0  1    3  $'\e(B\e[m'
+        xterm-256color  0  1    3  $'\e(B\e[m'
+        xterm-direct    0  1    3  $'\e(B\e[m'
+        xterm-256color  0  1   73  $'\e(B\e[m'
+        xterm-direct    0  1   73  $'\e(B\e[m'
+        xterm-direct    0  1  273  $'\e(B\e[m'
+
+        $TEST_TERM      1  1    3  $'\e(B\e[m\e[1m'
+        xterm-16color   1  1    3  $'\e(B\e[m\e[1m'
+        xterm-256color  1  1    3  $'\e(B\e[m\e[1m'
+        xterm-direct    1  1    3  $'\e(B\e[m\e[1m'
+        xterm-256color  1  1   73  $'\e(B\e[m\e[1m'
+        xterm-direct    1  1   73  $'\e(B\e[m\e[1m'
+        xterm-direct    1  1  273  $'\e(B\e[m\e[1m'
+    )
+    local _i _exp _ret
+    for ((_i = 0; _i < ${#_tests[@]}; _i += _tests_fields)); do
+        local _TERM=${_tests[_i]}
+        # skipping when xterm-direct not in terminfo, likely because ncurses is
+        # not >= 6.1.  FIXME: remove this when 6.1 is commonly available.
+        if [[ $_TERM == xterm-direct ]]; then
+            if ! tput -T "$_TERM" sgr0 &>/dev/null; then
+                printf '%s%s is not available, test skipped%s\n' \
+                       "$(tput setf 5)" "$_TERM" "$(tput sgr0)" >&2
+                continue
+            fi
+        fi
+        BOLD=${_tests[_i + 1]}
+        NOCOLOR=${_tests[_i + 2]}
+        C=(4 ${_tests[_i + 3]})  # put into C[1]
+        TERM=$_TERM parse
+        CATV_EXP_RET "${_tests[_i + 4]}" "${E[1]}"
+        $_ASSERT_EQUALS_ "'TERM=$TERM BOLD=$BOLD NOCOLOR=$NOCOLOR C=$C'" \
+                         "'$_exp'" "'$_ret'"
+    done
 }
 
 

--- a/test/test_parse.sh
+++ b/test/test_parse.sh
@@ -137,6 +137,23 @@ test_c_3() {
 }
 
 
+test_c_hex() {
+    TERM=xterm-256color parse -c#f -c#1f -c '#AF'
+    $_ASSERT_EQUALS_ "'15 31 175'" "'${C[*]}'"
+
+    # skipping when xterm-direct not in terminfo, likely because ncurses is not
+    # >= 6.1.  FIXME: remove this when 6.1 is commonly available.
+    if ! tput -T xterm-direct sgr0 &>/dev/null; then
+        printf '%s%s is not available, test skipped%s\n' \
+               "$(tput setf 5)" xterm-direct "$(tput sgr0)" >&2
+        return
+    fi
+    C=()
+    TERM=xterm-direct parse -c#C001AF
+    $_ASSERT_EQUALS_ 12583343 "'${C[*]}'"
+}
+
+
 test_c_3_1_4() {
     TERM=$TEST_TERM parse -c 3 -c 1 -c 4
 

--- a/test/test_parse.sh
+++ b/test/test_parse.sh
@@ -26,44 +26,15 @@ source "$(dirname "${BASH_SOURCE[0]}")"/helper.sh
 
 setUp() {
     source "$PIPESSH"
-}
 
-
-test_COLORS() {
-    TERM=$TEST_TERM parse
-    $_ASSERT_EQUALS_ 8 $COLORS
-    TERM=xterm-16color parse
-    $_ASSERT_EQUALS_ 16 $COLORS
-    TERM=xterm-256color parse
-    $_ASSERT_EQUALS_ 256 $COLORS
-    # skipping when xterm-direct not in terminfo, likely because ncurses is not
-    # >= 6.1.  FIXME: remove this when 6.1 is commonly available.
-    if ! tput -T xterm-direct sgr0 &>/dev/null; then
-        printf '%s%s is not available, test skipped%s\n' \
-               "$(tput setf 5)" xterm-direct "$(tput sgr0)" >&2
-        return
-    fi
-    TERM=xterm-direct parse
-    $_ASSERT_EQUALS_ 16777216 $COLORS
-}
-
-
-test_SGRs() {
-    TERM=$TEST_TERM parse
-
-    local _exp _ret
-    CATV_EXP_RET     $'\e(B\e[m' "$SGR0"
-    $_ASSERT_EQUALS_ "'$_exp'"   "'$_ret'"
-
-    CATV_EXP_RET     $'\e[1m'    "$SGR_BOLD"
-    $_ASSERT_EQUALS_ "'$_exp'"   "'$_ret'"
+    COLORS=8
 }
 
 
 # this fails when default settings are changed, which should be not changed
 # without a discussion.
 test_default_settings() {
-    TERM=$TEST_TERM parse
+    parse
 
     $_ASSERT_EQUALS_    1 "$p"
     $_ASSERT_EQUALS_   75 "$f"
@@ -76,209 +47,138 @@ test_default_settings() {
     $_ASSERT_EQUALS_ 0 "$NOCOLOR"
     $_ASSERT_EQUALS_ 0 "$KEEPCT"
 
-    $_ASSERT_EQUALS_ 0 "'${V[*]}'"
-    $_ASSERT_EQUALS_ 1 "$VN"
-    $_ASSERT_EQUALS_ "'1 2 3 4 5 6 7 0'" "'${C[*]}'"
-    $_ASSERT_EQUALS_ 8 "$CN"
+    $_ASSERT_EQUALS_ "''" "'${V[*]}'"
+    $_ASSERT_EQUALS_ "''" "'${C[*]}'"
 }
 
 
 test_p_0_invalid() {
-    TERM=$TEST_TERM parse -p 0
+    parse -p 0
 
     $_ASSERT_EQUALS_ 1 "$p"
 }
 
 
 test_p_2() {
-    TERM=$TEST_TERM parse -p 2
+    parse -p 2
 
     $_ASSERT_EQUALS_ 2 "$p"
 }
 
 
 test_t_3() {
-    TERM=$TEST_TERM parse -t 3
+    parse -t 3
 
     $_ASSERT_EQUALS_ 3 "'${V[@]}'"
-    $_ASSERT_EQUALS_ 1 "$VN"
 }
 
 
 test_t_3_1_4() {
-    TERM=$TEST_TERM parse -t 3 -t 1 -t 4
+    parse -t 3 -t 1 -t 4
 
     $_ASSERT_EQUALS_ "'3 1 4'" "'${V[*]}'"
-    $_ASSERT_EQUALS_ 3 "$VN"
 }
 
 
 test_t_999_outofrange() {
-    TERM=$TEST_TERM parse -t 999
+    parse -t 999
 
-    $_ASSERT_EQUALS_ 0 "'${V[*]}'"
-    $_ASSERT_EQUALS_ 1 "$VN"
+    $_ASSERT_EQUALS_ "''" "'${V[*]}'"
 }
 
 
 test_t_custom() {
     local _t=fedcba9876543210
-    TERM=$TEST_TERM parse -t "c$_t"
+    parse -t "c$_t"
 
     $_ASSERT_EQUALS_ "$_t" "${sets[V[VN-1]]}"
 }
 
 
 test_c_3() {
-    TERM=$TEST_TERM parse -c 3
+    parse -c 3
 
     $_ASSERT_EQUALS_ 3 "'${C[*]}'"
-    $_ASSERT_EQUALS_ 1 "$CN"
 }
 
 
 test_c_hex() {
-    TERM=xterm-256color parse -c#f -c#1f -c '#AF'
+    COLORS=256
+    parse -c#f -c#1f -c '#AF'
     $_ASSERT_EQUALS_ "'15 31 175'" "'${C[*]}'"
 
-    # skipping when xterm-direct not in terminfo, likely because ncurses is not
-    # >= 6.1.  FIXME: remove this when 6.1 is commonly available.
-    if ! tput -T xterm-direct sgr0 &>/dev/null; then
-        printf '%s%s is not available, test skipped%s\n' \
-               "$(tput setf 5)" xterm-direct "$(tput sgr0)" >&2
-        return
-    fi
+    COLORS=16777216
     C=()
-    TERM=xterm-direct parse -c#C001AF
+    parse -c#C001AF
     $_ASSERT_EQUALS_ 12583343 "'${C[*]}'"
 }
 
 
 test_c_3_1_4() {
-    TERM=$TEST_TERM parse -c 3 -c 1 -c 4
+    parse -c 3 -c 1 -c 4
 
     $_ASSERT_EQUALS_ "'3 1 4'" "'${C[*]}'"
-    $_ASSERT_EQUALS_ 3 "$CN"
 }
 
 
-test_c_8_outofrange() {
-    TERM=$TEST_TERM parse -c 8
+test_c_8_1_9_2_outofrange() {
+    parse -c 8
+    $_ASSERT_EQUALS_ "''" "'${C[*]}'"
 
-    $_ASSERT_EQUALS_ "'1 2 3 4 5 6 7 0'" "'${C[*]}'"
-    $_ASSERT_EQUALS_ 8 "$CN"
+    parse -c{8,1,9,2}
+    $_ASSERT_EQUALS_ "'1 2'" "'${C[*]}'"
 }
 
 
 test_f_50() {
-    TERM=$TEST_TERM parse -f 50
+    parse -f 50
 
     $_ASSERT_EQUALS_ 50 "$f"
 }
 
 
 test_f_10_invalid() {
-    TERM=$TEST_TERM parse -f 10
+    parse -f 10
 
     $_ASSERT_EQUALS_ 75 "$f"
 }
 
 
 test_s_10() {
-    TERM=$TEST_TERM parse -s 10
+    parse -s 10
 
     $_ASSERT_EQUALS_ 10 "$s"
 }
 
 
 test_s_30_invalid() {
-    TERM=$TEST_TERM parse -s 30
+    parse -s 30
 
     $_ASSERT_EQUALS_ 13 "$s"
 }
 
 
 test_r_0() {
-    TERM=$TEST_TERM parse -r 0
+    parse -r 0
 
     $_ASSERT_EQUALS_ 0 "$r"
 }
 
 
 test_r__1_invalid() {
-    TERM=$TEST_TERM parse -r -1
+    parse -r -1
 
     $_ASSERT_EQUALS_ 2000  "$r"
 }
 
 
 test_RBCK() {
-    TERM=$TEST_TERM parse -R -B -C -K
+    parse -R -B -C -K
 
     $_ASSERT_EQUALS_ 1 "$RNDSTART"
     $_ASSERT_EQUALS_ 0 "$BOLD"
     $_ASSERT_EQUALS_ 1 "$NOCOLOR"
     $_ASSERT_EQUALS_ 1 "$KEEPCT"
-}
-
-
-test_E() {
-    local _tests_fields=5
-    local _tests=(
-    #   TERM            BOLD    C  E
-    #                      NOCOLOR
-        $TEST_TERM      0  0    3  $'\e(B\e[m\e[33m'
-        xterm-16color   0  0    3  $'\e(B\e[m\e[33m'
-        xterm-256color  0  0    3  $'\e(B\e[m\e[33m'
-        xterm-direct    0  0    3  $'\e(B\e[m\e[33m'
-        xterm-256color  0  0   73  $'\e(B\e[m\e[38;5;73m'
-        xterm-direct    0  0   73  $'\e(B\e[m\e[38:2::0:0:73m'
-        xterm-direct    0  0  273  $'\e(B\e[m\e[38:2::0:1:17m'
-
-        $TEST_TERM      1  0    3  $'\e(B\e[m\e[1m\e[33m'
-        xterm-16color   1  0    3  $'\e(B\e[m\e[1m\e[33m'
-        xterm-256color  1  0    3  $'\e(B\e[m\e[1m\e[33m'
-        xterm-direct    1  0    3  $'\e(B\e[m\e[1m\e[33m'
-        xterm-256color  1  0   73  $'\e(B\e[m\e[1m\e[38;5;73m'
-        xterm-direct    1  0   73  $'\e(B\e[m\e[1m\e[38:2::0:0:73m'
-        xterm-direct    1  0  273  $'\e(B\e[m\e[1m\e[38:2::0:1:17m'
-
-        $TEST_TERM      0  1    3  $'\e(B\e[m'
-        xterm-16color   0  1    3  $'\e(B\e[m'
-        xterm-256color  0  1    3  $'\e(B\e[m'
-        xterm-direct    0  1    3  $'\e(B\e[m'
-        xterm-256color  0  1   73  $'\e(B\e[m'
-        xterm-direct    0  1   73  $'\e(B\e[m'
-        xterm-direct    0  1  273  $'\e(B\e[m'
-
-        $TEST_TERM      1  1    3  $'\e(B\e[m\e[1m'
-        xterm-16color   1  1    3  $'\e(B\e[m\e[1m'
-        xterm-256color  1  1    3  $'\e(B\e[m\e[1m'
-        xterm-direct    1  1    3  $'\e(B\e[m\e[1m'
-        xterm-256color  1  1   73  $'\e(B\e[m\e[1m'
-        xterm-direct    1  1   73  $'\e(B\e[m\e[1m'
-        xterm-direct    1  1  273  $'\e(B\e[m\e[1m'
-    )
-    local _i _exp _ret
-    for ((_i = 0; _i < ${#_tests[@]}; _i += _tests_fields)); do
-        local _TERM=${_tests[_i]}
-        # skipping when xterm-direct not in terminfo, likely because ncurses is
-        # not >= 6.1.  FIXME: remove this when 6.1 is commonly available.
-        if [[ $_TERM == xterm-direct ]]; then
-            if ! tput -T "$_TERM" sgr0 &>/dev/null; then
-                printf '%s%s is not available, test skipped%s\n' \
-                       "$(tput setf 5)" "$_TERM" "$(tput sgr0)" >&2
-                continue
-            fi
-        fi
-        BOLD=${_tests[_i + 1]}
-        NOCOLOR=${_tests[_i + 2]}
-        C=(4 ${_tests[_i + 3]})  # put into C[1]
-        TERM=$_TERM parse
-        CATV_EXP_RET "${_tests[_i + 4]}" "${E[1]}"
-        $_ASSERT_EQUALS_ "'TERM=$TERM BOLD=$BOLD NOCOLOR=$NOCOLOR C=$C'" \
-                         "'$_exp'" "'$_ret'"
-    done
 }
 
 


### PR DESCRIPTION
See the (first) commit for detailed changes, but in short, this PR enables these:

```bash
TERM=st-256color ./pipes.sh -c{240..255} -p16 -r0 -t2 -R
```

![2018-04-16--15 31 04](https://user-images.githubusercontent.com/30909/38795698-a617ba26-418b-11e8-9f8d-6463e3ffabcc.png)

```bash
TERM=st-direct ./pipes.sh -c{128..255..16} -p8 -r0 -t2 -R
```

![2018-04-16--15 32 02](https://user-images.githubusercontent.com/30909/38795712-b0a02230-418b-11e8-8d8f-c7dcdf66a3b7.png)

*(By the way, I felt I spent more mind power trying to (absolutely blindly) resolve the testing environment issue on Travis CI for the ncurses < 6.1 than coding this patch.  In the end, just skipping those tests for sack of my mental health, because 6.1 has only been released for about three months.)*