### PR TITLE
error out on invalid option name and argument

### DIFF
--- a/test/test_command.sh
+++ b/test/test_command.sh
@@ -58,4 +58,30 @@ test_command_TERM() {
 }
 
 
+# test invalid option arguments using
+#   $1: option name
+#   $2-: invalid option arguments to be parsed one by one
+# parse() must return 1
+_test_args_invalid() {
+    local _opt=$1
+    shift
+    while (($#)); do
+        run "$PIPESSH" -$_opt "$1" 2>/dev/null
+        $_ASSERT_EQUALS_ "'-$_opt $1'" 1 "'$status'"
+        shift
+    done
+}
+
+
+test_invalid_arg() {
+    _test_args_invalid p 0 NaN
+    _test_args_invalid t NaN
+    TERM=$TEST_TERM _test_args_invalid c 9 '#f' '#z' NaN
+    TERM=xterm-256color _test_args_invalid c 256 '#100' '#z' NaN cfoobar
+    _test_args_invalid f 0 19 101 NaN
+    _test_args_invalid s 0 4 16 NaN
+    _test_args_invalid r NaN
+}
+
+
 source shunit2


### PR DESCRIPTION
Prior to this commit:

- `getopts` prints out error message for invalid option name, but script
  isn't halted.

- invalid arguments, such as out of valid range, could be discarded
  silently or replaced with a reasonably valid argument, also silently.

This commit forces to exit with status 1 at the point where the invalid
option name or argument is detected, with an error message from `getopts`
or the script.