### PR TITLE
optimize sets[] pipe char access

### DIFF
--- a/pipes.sh
+++ b/pipes.sh
@@ -52,6 +52,7 @@ sets=(
     "-\ /\|/  /-\/ \|"  # railway
     "╿┍ ┑┚╼┒  ┕╽┙┖ ┎╾"  # knobby pipe
 )
+SETS=()  # rearranged all pipe chars into individul elements for easier access
 
 # pipes'
 x=()  # current position
@@ -213,6 +214,16 @@ main() {
     }
     # -_CP_init_E
 
+    # +_CP_init_SETS
+    local i j
+    for ((i = 0; i < ${#sets[@]}; i++)) {
+        for ((j = 0; j < 16; j++)) {
+            SETS+=("${sets[i]:j:1}")
+        }
+    }
+    unset i j
+    # -_CP_init_SETS
+
     init_screen
     init_pipes
 
@@ -266,7 +277,7 @@ main() {
             # +_CP_print
             printf '\e[%d;%dH%s%s'                      \
                    $((y[i] + 1)) $((x[i] + 1)) ${c[i]}  \
-                   "${sets[v[i]]:l[i]*4+n[i]:1}"
+                   "${SETS[v[i] * 16 + l[i] * 4 + n[i]]}"
             # -_CP_print
             l[i]=${n[i]}
         done

--- a/test/test_main.sh
+++ b/test/test_main.sh
@@ -43,6 +43,7 @@ setUp() {
     VN=${#C[@]}
 
     sets[V[i]]='0123456789ABCDEF'
+    _CP_init_SETS
 
     BOLD=1
     NOCOLOR=0
@@ -173,6 +174,24 @@ test_init_E() {
         $_ASSERT_EQUALS_ "'TERM=$TERM BOLD=$BOLD NOCOLOR=$NOCOLOR C=$C'" \
                          "'$_exp'" "'$_ret'"
     done
+}
+
+
+test_init_SETS() {
+    local _exp
+
+    unset SETS
+    sets=('1234567890abcdef')
+    _CP_init_SETS
+    _exp='1 2 3 4 5 6 7 8 9 0 a b c d e f'
+    $_ASSERT_EQUALS_ "'$_exp'" "'${SETS[*]}'"
+
+    unset SETS
+    sets=('1234567890abcdef' 'foobarABCDEFGHIJ')
+    _CP_init_SETS
+     _exp='1 2 3 4 5 6 7 8 9 0 a b c d e f '
+    _exp+='f o o b a r A B C D E F G H I J'
+    $_ASSERT_EQUALS_ "'$_exp'" "'${SETS[*]}'"
 }
 
 


### PR DESCRIPTION
By putting all chars of each 16-char strings into `SETS[]` as individual
elements, and the performance slightly improved:

    $ LIMIT=30000 TIMEF=time_ndis scripts/benchmark.sh 7f82b19 .
    7f82b19   :   3785 c/s
    .         :   3835 c/s