### PR TITLE
allow setting the installation location by environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SCRIPT  = pipes.sh
 MANPAGE = $(SCRIPT).6
 GEN_MAN = scripts/gen-man-html.sh
 
-PREFIX  = /usr/local
+PREFIX  ?= /usr/local
 DESTDIR =
 INSTDIR = $(DESTDIR)$(PREFIX)
 INSTBIN = $(INSTDIR)/bin


### PR DESCRIPTION
I wanted to install in `~/.local/bin`, but that looked impossible.
So I looked into it, and a simple `?` solved my problem :smile: 

This allowed me to override the PREFIX variable like so:

```
$ PREFIX=~/.local make install
test -d /home/$USER/.local || mkdir -p /home/$USER/.local
test -d /home/$USER/.local/bin || mkdir -p /home/$USER/.local/bin
test -d /home/$USER/.local/share/man/man6 || mkdir -p /home/$USER/.local/share/man/man6
install -m 0755 pipes.sh /home/$USER/.local/bin
install -m 0644 pipes.sh.6 /home/$USER/.local/share/man/man6
```
`$ make install PREFIX=~/local` works as well

You can still use the default
```
$ make install
test -d /usr/local || mkdir -p /usr/local
test -d /usr/local/bin || mkdir -p /usr/local/bin
test -d /usr/local/share/man/man6 || mkdir -p /usr/local/share/man/man6
install -m 0755 pipes.sh /usr/local/bin
install -m 0644 pipes.sh.6 /usr/local/share/man/man6
```