### PR TITLE
Add a snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,19 @@
+name: pipes-sh
+base: core18
+version: git
+summary: Animated pipes terminal screensaver
+description: |
+  Animated pipes terminal screensaver.
+grade: stable
+confinement: strict
+
+parts:
+  pipes:
+    plugin: make
+    source: .
+
+apps:
+  pipes-sh:
+    command: usr/local/bin/pipes.sh
+    environment:
+      LC_ALL: C.UTF-8


### PR DESCRIPTION
Hi, I stumbled upon pipes but couldn't find any packages for it. I work on Snapcraft, so I put together a snap of it. If you build this locally and push to the Snap Store, millions of Linux users can [browse](https://snapcraft.io/store) their way to it.

To build, `snap install snapcraft` from Ubuntu, or [install Multipass](https://github.com/CanonicalLtd/multipass/releases) on MacOS then `brew install snapcraft`. Then run `snapcraft`.

To publish, [create an account](https://snapcraft.io/account), then:
```
snapcraft login
snapcraft register pipes-sh
snapcraft push --release=stable *.snap
```