### PR TITLE
Fixed a typo in comment

### DIFF
--- a/pipes.sh
+++ b/pipes.sh
@@ -52,7 +52,7 @@ sets=(
     "-\ /\|/  /-\/ \|"  # railway
     "╿┍ ┑┚╼┒  ┕╽┙┖ ┎╾"  # knobby pipe
 )
-SETS=()  # rearranged all pipe chars into individul elements for easier access
+SETS=()  # rearranged all pipe chars into individual elements for easier access
 
 # pipes'
 x=()  # current position


### PR DESCRIPTION
Fixed a typo in the comment on line 55
From "individul elements" to "individual elements"