### PR TITLE
clear, instead of tput reset

### DIFF
--- a/pipes.sh
+++ b/pipes.sh
@@ -226,7 +226,7 @@ cleanup() {
     # clear out standard input
     read -t 0.001 && cat </dev/stdin>/dev/null
 
-    tput reset  # fix for konsole, see pipeseroni/pipes.sh#43
+    clear # fix for konsole, see pipeseroni/pipes.sh#43
     tput rmcup
     tput cnorm
     stty echo
@@ -374,7 +374,7 @@ main() {
             # -_CP_print
             l[i]=${n[i]}
         done
-        ((r > 0 && t * p >= r)) && tput reset && tput civis && t=0 || ((t++))
+        ((r > 0 && t * p >= r)) && clear && tput civis && t=0 || ((t++))
     done
 
     cleanup


### PR DESCRIPTION
I made this so color scheme doesn't get reset, I was facing this problem with pywal, and it was very furstrating.

I'm not sure if this is the only file I had to edit, but for me, this was it all (I only installed the pipes.sh file and ran it using bash pipes.sh, ofc I created an alias for it) :)